### PR TITLE
feature/schema subscription removal

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
     </PropertyGroup>
 </Project>

--- a/src/GraphQL-Client/Configuration/GraphQLClientConfiguration.cs
+++ b/src/GraphQL-Client/Configuration/GraphQLClientConfiguration.cs
@@ -15,7 +15,7 @@ public class GraphQLClientConfiguration : IGraphQLClientConfiguration
         bool validateAssemblies,
         bool removeSubscriptionsFromSchema,
         HttpClient httpClient
-        )
+    )
     {
         HttpClient = httpClient;
         HttpClient.BaseAddress = baseAddress;
@@ -47,6 +47,6 @@ public class GraphQLClientConfiguration : IGraphQLClientConfiguration
     public HttpClient HttpClient { get; init; }
 
     public bool DisposeHttpClient { get; init; }
-    
-    public bool RemoveSubscriptionsFromSchema { get; init; } 
+
+    public bool RemoveSubscriptionsFromSchema { get; init; }
 }

--- a/src/GraphQL-Client/Configuration/GraphQLClientConfiguration.cs
+++ b/src/GraphQL-Client/Configuration/GraphQLClientConfiguration.cs
@@ -13,8 +13,9 @@ public class GraphQLClientConfiguration : IGraphQLClientConfiguration
         JsonSerializerOptions jsonSerializerOptions,
         bool disposeHttpClient,
         bool validateAssemblies,
+        bool removeSubscriptionsFromSchema,
         HttpClient httpClient
-    )
+        )
     {
         HttpClient = httpClient;
         HttpClient.BaseAddress = baseAddress;
@@ -24,6 +25,7 @@ public class GraphQLClientConfiguration : IGraphQLClientConfiguration
         WebsocketJsonSerializer = jsonSerializer;
         ValidateAssemblies = validateAssemblies;
         DisposeHttpClient = disposeHttpClient;
+        RemoveSubscriptionsFromSchema = removeSubscriptionsFromSchema;
 
         GraphQLHttpClient = new GraphQLHttpClient(
             serializer: jsonSerializer,
@@ -45,4 +47,6 @@ public class GraphQLClientConfiguration : IGraphQLClientConfiguration
     public HttpClient HttpClient { get; init; }
 
     public bool DisposeHttpClient { get; init; }
+    
+    public bool RemoveSubscriptionsFromSchema { get; init; } 
 }

--- a/src/GraphQL-Client/Configuration/GraphQLClientConfigurationBuilder.cs
+++ b/src/GraphQL-Client/Configuration/GraphQLClientConfigurationBuilder.cs
@@ -17,6 +17,7 @@ public class GraphQLClientConfigurationBuilder(Uri baseAddress)
             JsonSerializerOptions,
             DisposeHttpClient,
             ValidateAssemblies,
+            RemoveSubscriptionsFromSchema,
             HttpClient
         );
 
@@ -41,4 +42,10 @@ public class GraphQLClientConfigurationBuilder(Uri baseAddress)
     public HttpClient HttpClient { get; set; } = new();
 
     public bool DisposeHttpClient { get; set; } = false;
+
+    /// <summary>
+    /// Subscriptions in the schema will require a subscription type to be added to every single client query made,
+    /// regardless of if they interact with the subscription or not, so they may be removed from the schema if not needed.
+    /// </summary>
+    public bool RemoveSubscriptionsFromSchema { get; set; } = true;
 }

--- a/src/GraphQL-Client/Configuration/IGraphQLClientConfiguration.cs
+++ b/src/GraphQL-Client/Configuration/IGraphQLClientConfiguration.cs
@@ -19,6 +19,6 @@ public interface IGraphQLClientConfiguration
     public HttpClient HttpClient { get; }
 
     public bool DisposeHttpClient { get; }
-    
+
     public bool RemoveSubscriptionsFromSchema { get; }
 }

--- a/src/GraphQL-Client/Configuration/IGraphQLClientConfiguration.cs
+++ b/src/GraphQL-Client/Configuration/IGraphQLClientConfiguration.cs
@@ -19,4 +19,6 @@ public interface IGraphQLClientConfiguration
     public HttpClient HttpClient { get; }
 
     public bool DisposeHttpClient { get; }
+    
+    public bool RemoveSubscriptionsFromSchema { get; }
 }

--- a/src/GraphQL-Client/Extensions/GraphQLClientConfigurationExtensions.cs
+++ b/src/GraphQL-Client/Extensions/GraphQLClientConfigurationExtensions.cs
@@ -31,7 +31,10 @@ public static class GraphQLClientConfigurationExtensions
         return response.Data;
     }
 
-    public static ISchema AsSchema(this JsonElement schemaJson, IGraphQLClientConfiguration configuration)
+    public static ISchema AsSchema(
+        this JsonElement schemaJson,
+        IGraphQLClientConfiguration configuration
+    )
     {
         var schemaResponse = schemaJson.Deserialize<GraphQLData>(
             new JsonSerializerOptions

--- a/src/GraphQL-Client/Extensions/GraphQLClientConfigurationExtensions.cs
+++ b/src/GraphQL-Client/Extensions/GraphQLClientConfigurationExtensions.cs
@@ -11,7 +11,7 @@ namespace GraphQL;
 public static class GraphQLClientConfigurationExtensions
 {
     public static ISchema IntrospectSchema(this IGraphQLClientConfiguration configuration) =>
-        FetchSchemaJson(configuration).AsSchema();
+        FetchSchemaJson(configuration).AsSchema(configuration);
 
     public static JsonElement FetchSchemaJson(IGraphQLClientConfiguration configuration)
     {
@@ -31,7 +31,7 @@ public static class GraphQLClientConfigurationExtensions
         return response.Data;
     }
 
-    public static ISchema AsSchema(this JsonElement schemaJson)
+    public static ISchema AsSchema(this JsonElement schemaJson, IGraphQLClientConfiguration configuration)
     {
         var schemaResponse = schemaJson.Deserialize<GraphQLData>(
             new JsonSerializerOptions
@@ -47,6 +47,9 @@ public static class GraphQLClientConfigurationExtensions
                 $"Could not get data from __schema introspection. Data likely came back null. Schema: ({schemaJson.GetRawText()})"
             );
         }
+
+        if (configuration.RemoveSubscriptionsFromSchema)
+            schemaResponse.__Schema.SubscriptionType = null;
 
         var converter = new ASTConverter();
         var document = converter.ToDocument(schemaResponse.__Schema);


### PR DESCRIPTION
Subscriptions in the schema validated against will currently cause ***ALL*** Client Requests against them fail, unless they additionally include a subscription handler, and given the current way the library functions, it isn't possible to combine two requests before validating them, therefore validating any request against a schema with a subscription is currently impossible. This change adds the ability to remove the subscriptions from the schema being validated against completely, which then allows requests to again validate. This will likely need to be removed  eventually once the library supports subscriptions